### PR TITLE
Specifiy base to count digits

### DIFF
--- a/src/math/armstrong_number.cairo
+++ b/src/math/armstrong_number.cairo
@@ -12,7 +12,7 @@ use quaireaux::utils;
 /// # Returns
 /// * `bool` - A boolean value indicating is Armstrong Number.
 fn is_armstrong_number(num: felt) -> bool {
-    _is_armstrong_number(num, num, utils::count_digits(num))
+    _is_armstrong_number(num, num, utils::count_digits_of_base(num, 10))
 }
 
 /// Recursive helper function for 'is_armstrong_number'.

--- a/src/math/karatsuba.cairo
+++ b/src/math/karatsuba.cairo
@@ -32,7 +32,7 @@ fn multiply(x: felt, y: felt) -> felt {
         return x * y;
     }
 
-    let max_digit_counts = utils::max(utils::count_digits(x), utils::count_digits(y));
+    let max_digit_counts = utils::max(utils::count_digits_of_base(x, 10), utils::count_digits_of_base(y, 10));
     let middle_idx = _div_half_ceil(max_digit_counts);
     let (x1, x0) = _split_number(x, middle_idx);
     let (y1, y0) = _split_number(y, middle_idx);

--- a/src/tests.cairo
+++ b/src/tests.cairo
@@ -11,3 +11,4 @@ mod queue_test;
 mod stack_test;
 mod perfect_number_test;
 mod armstrong_number_test;
+mod utils_test;

--- a/src/tests/utils_test.cairo
+++ b/src/tests/utils_test.cairo
@@ -1,0 +1,27 @@
+// Core library imports.
+use option::OptionTrait;
+use array::ArrayTrait;
+
+use quaireaux::utils;
+
+// Test power function
+#[test]
+#[available_gas(2000000)]
+fn count_digits_of_base_test() {
+    assert(utils::count_digits_of_base(0, 10) == 0, 'invalid result');
+    assert(utils::count_digits_of_base(2, 10) == 1, 'invalid result');
+    assert(utils::count_digits_of_base(10, 10) == 2, 'invalid result');
+    assert(utils::count_digits_of_base(100, 10) == 3, 'invalid result');
+    assert(utils::count_digits_of_base(0x80, 16) == 2, 'invalid result');
+    assert(utils::count_digits_of_base(0x800, 16) == 3, 'invalid result');
+    assert(utils::count_digits_of_base(0x888888888888888888, 16) == 18, 'invalid result');
+}
+
+// Test for power function
+#[test]
+#[available_gas(2000000)]
+fn pow_test() {
+    assert(utils::pow(2, 0) == 1, 'invalid result');
+    assert(utils::pow(2, 1) == 2, 'invalid result');
+    assert(utils::pow(2, 12) == 4096, 'invalid result');
+}

--- a/src/utils.cairo
+++ b/src/utils.cairo
@@ -56,19 +56,10 @@ fn max(a: felt, b: felt) -> felt {
 // Function to count the number of digits in a number.
 /// # Arguments
 /// * `num` - The number to count the digits of.
+/// * `base` - Base in which to count the digits.
 /// # Returns
-/// * `felt` - The number of digits in num.
-fn count_digits(num: felt) -> felt {
-    _count_digits(num, 0, 1)
-}
-
-// Recursive helper function for 'count_digits'.
-/// * `num` - The number to count the digits of.
-/// * `count` - The current count of digits.
-/// * `divisor` - The divisor used in the calculation to separate the digits.
-/// # Returns
-/// * `felt` - The number of digits in num.
-fn _count_digits(num: felt, count: felt, divisor: felt) -> felt {
+/// * `felt` - The number of digits in num of base
+fn count_digits_of_base(num: felt, base: felt) -> felt {
     // Check if out of gas.
     // TODO: Remove when automatically handled by compiler.
     match get_gas() {
@@ -80,11 +71,13 @@ fn _count_digits(num: felt, count: felt, divisor: felt) -> felt {
         }
     }
 
-    let quotient = unsafe_euclidean_div_no_remainder(num, divisor);
-    if quotient < 10 {
-        return count + 1;
+    match num {
+        0 => 0,
+        _ => {
+            let quotient = unsafe_euclidean_div_no_remainder(num, base);
+            count_digits_of_base(quotient, base) + 1
+        }
     }
-    return _count_digits(num, count + 1, divisor * 10);
 }
 
 // Raise a number to a power.


### PR DESCRIPTION
Add an option to specifiy a base to count digits
Add tests to utils

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, `count_digits` only count with base 10 

## What is the new behavior?

Specifying a base to count digits makes it simpler to count digits/bytes/nibles 

## Does this introduce a breaking change?

- [X] Yes
- [ ] No

Calls to `count_digits` need to be updates

## Other information

