### PR TITLE
fix: add use integer

### DIFF
--- a/src/utils.cairo
+++ b/src/utils.cairo
@@ -1,6 +1,8 @@
 //! Utilities for quaireaux standard library.
 use array::ArrayTrait;
 use option::OptionTrait;
+use integer::u128_try_from_felt;
+use integer::u128_to_felt;
 
 /// Panic with a custom message.
 /// # Arguments


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Fix the compilation failure arising from missing imports.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Code from `utils.cairo` fails to compile with the following error:
```
error: Function not found.
 --> utils.cairo:33:15
    let res = u128_try_from_felt(a);
              ^****************^

error: Function not found.
 --> utils.cairo:41:5
    u128_to_felt(a_u128 / b_u128)
    ^**********^

error: Function not found.
 --> utils.cairo:47:6
    (u128_to_felt(a_u128 / b_u128), u128_to_felt(a_u128 % b_u128))
     ^**********^

error: Function not found.
 --> utils.cairo:47:37
    (u128_to_felt(a_u128 / b_u128), u128_to_felt(a_u128 % b_u128))
                                    ^**********^

Error: failed to compile: .
```

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
Code compiles and all tests pass.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
