### PR TITLE
fix: use ref in `stack.pop()`

### DIFF
--- a/src/data_structures/stack.cairo
+++ b/src/data_structures/stack.cairo
@@ -10,7 +10,7 @@
 //! let mut item:u256 = 1.into();
 //! stack.push(item);
 //! Remove the item from the stack;
-//! let (stack, _) = stack.pop();
+//! let item = stack.pop();
 //! ```
 
 // Core lib imports
@@ -31,7 +31,7 @@ trait StackTrait {
     /// Pushes a new value onto the stack.
     fn push(ref self: Stack, value: u256);
     /// Removes the last item from the stack and returns it, or None if the stack is empty.
-    fn pop(self: Stack) -> (Stack, Option::<u256>);
+    fn pop(ref self: Stack) -> Option::<u256>;
     /// Returns the last item from the stack without removing it, or None if the stack is empty.
     fn peek(self: @Stack) -> Option::<u256>;
     /// Returns the number of items in the stack.
@@ -65,9 +65,9 @@ impl StackImpl of StackTrait {
     /// Returns
     /// * Stack The stack with the item removed.
     /// * Option::<u256> The item removed or None if the stack is empty.
-    fn pop(mut self: Stack) -> (Stack, Option::<u256>) {
+    fn pop(ref self: Stack) -> Option::<u256> {
         if self.is_empty() {
-            return (self, Option::None(()));
+            return Option::None(());
         }
         // Deconstruct the stack struct because we consume it
         let Stack{elements: mut elements } = self;
@@ -79,7 +79,7 @@ impl StackImpl of StackTrait {
         let value = elements.at(last_idx);
         // Update the returned stack with the sliced array
         self = Stack { elements: sliced_elements };
-        (self, Option::Some(*value))
+        Option::Some(*value)
     }
 
     /// Returns the last item from the stack without removing it, or None if the stack is empty.

--- a/src/tests/stack_test.cairo
+++ b/src/tests/stack_test.cairo
@@ -72,7 +72,7 @@ fn stack_pop_test() {
     stack.push(val_1);
     stack.push(val_2);
 
-    let (mut stack, value) = stack.pop();
+    let value = stack.pop();
     match value {
         Option::Some(result) => {
             assert(result == val_2, 'wrong result');
@@ -85,5 +85,4 @@ fn stack_pop_test() {
     let result_len = stack.len();
     assert(result_len == 1_usize, 'should remove item');
 }
-
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Uses `ref` instead of a mutable value in `stack.pop()`

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [x] Yes (breaking API change)
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
