### PR TITLE
moving all math related fn to the math crate

### DIFF
--- a/quaireaux/math/src/aliquot_sum.cairo
+++ b/quaireaux/math/src/aliquot_sum.cairo
@@ -3,8 +3,8 @@
 // Core library imports.
 use option::OptionTrait;
 use array::ArrayTrait;
-use utils::utils::unsafe_euclidean_div;
-use utils::utils::unsafe_euclidean_div_no_remainder;
+use math::unsafe_euclidean_div;
+use math::unsafe_euclidean_div_no_remainder;
 use utils::utils::check_gas;
 
 /// Calculates the aliquot sum of a given number.

--- a/quaireaux/math/src/armstrong_number.cairo
+++ b/quaireaux/math/src/armstrong_number.cairo
@@ -3,9 +3,9 @@
 // Core library imports.
 use array::ArrayTrait;
 use option::OptionTrait;
-use utils::utils::unsafe_euclidean_div;
-use utils::utils::pow;
-use utils::utils::count_digits_of_base;
+use math::count_digits_of_base;
+use math::pow;
+use math::unsafe_euclidean_div;
 use utils::utils::check_gas;
 
 /// Armstrong Number Algorithm.

--- a/quaireaux/math/src/collatz_sequence.cairo
+++ b/quaireaux/math/src/collatz_sequence.cairo
@@ -3,7 +3,7 @@
 // Core library imports.
 use option::OptionTrait;
 use array::ArrayTrait;
-use utils::utils::unsafe_euclidean_div;
+use math::unsafe_euclidean_div;
 use utils::utils::check_gas;
 
 /// Generates the Collatz sequence for a given number.

--- a/quaireaux/math/src/extended_euclidean_algorithm.cairo
+++ b/quaireaux/math/src/extended_euclidean_algorithm.cairo
@@ -5,7 +5,7 @@ use option::OptionTrait;
 use array::ArrayTrait;
 
 use utils::utils::check_gas;
-use utils::utils::unsafe_euclidean_div_no_remainder;
+use math::unsafe_euclidean_div_no_remainder;
 
 /// Extended Euclidean Algorithm.
 /// # Arguments

--- a/quaireaux/math/src/fast_power.cairo
+++ b/quaireaux/math/src/fast_power.cairo
@@ -4,7 +4,7 @@
 use array::ArrayTrait;
 use option::OptionTrait;
 use utils::utils::check_gas;
-use utils::utils::unsafe_euclidean_div;
+use math::unsafe_euclidean_div;
 
 // Calculate the (base^power)mod modulus using the fast powering algorithm
 // # Arguments

--- a/quaireaux/math/src/gcd_of_n_numbers.cairo
+++ b/quaireaux/math/src/gcd_of_n_numbers.cairo
@@ -5,7 +5,7 @@ use option::OptionTrait;
 use array::ArrayTrait;
 
 use utils::utils::check_gas;
-use utils::utils::unsafe_euclidean_div;
+use math::unsafe_euclidean_div;
 
 // Calculate the greatest common dividor for n numbers
 // # Arguments

--- a/quaireaux/math/src/karatsuba.cairo
+++ b/quaireaux/math/src/karatsuba.cairo
@@ -5,6 +5,7 @@ use array::ArrayTrait;
 use option::OptionTrait;
 use traits::Into;
 // Internal imports.
+use math::pow;
 use quaireaux::utils;
 
 /// Algorithm to multiply two numbers in O(n^1.6) running time
@@ -35,7 +36,7 @@ fn multiply(x: u128, y: u128) -> u128 {
     let z1 = multiply(x1, y1);
     let z2 = multiply(x0 + x1, y0 + y1);
 
-    return z0 + (z2 - z0 - z1) * utils::pow(10, middle_idx) + z1 * utils::pow(10, 2 * middle_idx);
+    return z0 + (z2 - z0 - z1) * pow(10, middle_idx) + z1 * pow(10, 2 * middle_idx);
 }
 
 /// Helper function for 'multiply', divides an integer in half and rounds up strictly.
@@ -62,7 +63,7 @@ fn _div_half_ceil(num: u128) -> u128 {
 fn _split_number(num: u128, split_idx: u128) -> (u128, u128) {
     utils::check_gas();
 
-    let divisor = utils::pow(10, split_idx);
+    let divisor = pow(10, split_idx);
     let (q, r) = utils::unsafe_euclidean_div(num, divisor);
     (q, r)
 }

--- a/quaireaux/math/src/lib.cairo
+++ b/quaireaux/math/src/lib.cairo
@@ -1,3 +1,9 @@
+mod math;
+use math::pow;
+use math::count_digits_of_base;
+use math::unsafe_euclidean_div;
+use math::unsafe_euclidean_div_no_remainder;
+
 mod aliquot_sum;
 mod armstrong_number;
 mod collatz_sequence;

--- a/quaireaux/math/src/math.cairo
+++ b/quaireaux/math/src/math.cairo
@@ -1,0 +1,55 @@
+use option::OptionTrait;
+use traits::Into;
+use traits::TryInto;
+
+use utils::utils::check_gas;
+
+// Raise a number to a power.
+/// * `base` - The number to raise.
+/// * `exp` - The exponent.
+/// # Returns
+/// * `felt252` - The result of base raised to the power of exp.
+fn pow(base: felt252, exp: felt252) -> felt252 {
+    check_gas();
+
+    match exp {
+        0 => 1,
+        _ => base * pow(base, exp - 1),
+    }
+}
+
+// Function to count the number of digits in a number.
+/// # Arguments
+/// * `num` - The number to count the digits of.
+/// * `base` - Base in which to count the digits.
+/// # Returns
+/// * `felt252` - The number of digits in num of base
+fn count_digits_of_base(num: felt252, base: felt252) -> felt252 {
+    check_gas();
+
+    match num {
+        0 => 0,
+        _ => {
+            let quotient = unsafe_euclidean_div_no_remainder(num, base);
+            count_digits_of_base(quotient, base) + 1
+        }
+    }
+}
+
+/// Perform euclidean division on `felt252` types.
+fn unsafe_euclidean_div_no_remainder(a: felt252, b: felt252) -> felt252 {
+    let a_u128 = unsafe_felt252_to_u128(a);
+    let b_u128 = unsafe_felt252_to_u128(b);
+    (a_u128 / b_u128).into()
+}
+
+fn unsafe_euclidean_div(a: felt252, b: felt252) -> (felt252, felt252) {
+    let a_u128 = unsafe_felt252_to_u128(a);
+    let b_u128 = unsafe_felt252_to_u128(b);
+    ((a_u128 / b_u128).into(), (a_u128 % b_u128).into())
+}
+
+/// Force conversion from `felt252` to `u128`.
+fn unsafe_felt252_to_u128(a: felt252) -> u128 {
+    a.try_into().unwrap()
+}

--- a/quaireaux/math/src/perfect_number.cairo
+++ b/quaireaux/math/src/perfect_number.cairo
@@ -5,7 +5,7 @@ use option::OptionTrait;
 use array::ArrayTrait;
 
 use utils::utils::check_gas;
-use utils::utils::unsafe_euclidean_div;
+use math::unsafe_euclidean_div;
 
 /// Algorithm to determine if a number is a perfect number
 /// # Arguments

--- a/quaireaux/math/src/tests.cairo
+++ b/quaireaux/math/src/tests.cairo
@@ -5,6 +5,7 @@ mod extended_euclidean_algorithm_test;
 mod fast_power_test;
 mod fibonacci_test;
 mod gcd_of_n_numbers_test;
+mod math_test;
 mod perfect_number_test;
 mod signed_integers_test;
 mod zellers_congruence_test;

--- a/quaireaux/math/src/tests/math_test.cairo
+++ b/quaireaux/math/src/tests/math_test.cairo
@@ -1,0 +1,24 @@
+use math::pow;
+use math::count_digits_of_base;
+
+// Test for power function
+#[test]
+#[available_gas(2000000)]
+fn pow_test() {
+    assert(pow(2, 0) == 1, 'invalid result');
+    assert(pow(2, 1) == 2, 'invalid result');
+    assert(pow(2, 12) == 4096, 'invalid result');
+}
+
+// Test power function
+#[test]
+#[available_gas(2000000)]
+fn count_digits_of_base_test() {
+    assert(count_digits_of_base(0, 10) == 0, 'invalid result');
+    assert(count_digits_of_base(2, 10) == 1, 'invalid result');
+    assert(count_digits_of_base(10, 10) == 2, 'invalid result');
+    assert(count_digits_of_base(100, 10) == 3, 'invalid result');
+    assert(count_digits_of_base(0x80, 16) == 2, 'invalid result');
+    assert(count_digits_of_base(0x800, 16) == 3, 'invalid result');
+    assert(count_digits_of_base(0x888888888888888888, 16) == 18, 'invalid result');
+}

--- a/quaireaux/sorting/src/merge_sort.cairo
+++ b/quaireaux/sorting/src/merge_sort.cairo
@@ -5,7 +5,6 @@ use array::ArrayTrait;
 
 // Internal Imports
 use utils::utils::check_gas;
-use utils::utils::split_array;
 
 // Merge Sort
 /// # Arguments
@@ -87,3 +86,43 @@ impl TPartialOrd: PartialOrd::<T>>(
     }
 }
 
+// Split an array into two arrays.
+/// * `arr` - The array to split.
+/// * `index` - The index to split the array at.
+/// # Returns
+/// * `(Array::<T>, Array::<T>)` - The two arrays.
+fn split_array<T, impl TCopy: Copy::<T>>(
+    ref arr: Array::<T>, index: usize
+) -> (Array::<T>, Array::<T>) {
+    check_gas();
+
+    let mut arr1 = ArrayTrait::new();
+    let mut arr2 = ArrayTrait::new();
+    let len = arr.len();
+
+    fill_array(ref arr1, ref arr, 0_u32, index);
+    fill_array(ref arr2, ref arr, index, len - index);
+
+    (arr1, arr2)
+}
+
+// Fill an array with a value.
+/// * `arr` - The array to fill.
+/// * `fill_arr` - The array to fill with.
+/// * `index` - The index to start filling at.
+/// * `count` - The number of elements to fill.
+/// # Returns
+/// * `Array::<T>` - The filled array.
+fn fill_array<T, impl TCopy: Copy::<T>>(
+    ref arr: Array::<T>, ref fill_arr: Array::<T>, index: usize, count: usize
+) {
+    check_gas();
+
+    if count == 0_usize {
+        return ();
+    }
+    let element = fill_arr.at(index);
+    arr.append(*element);
+
+    fill_array(ref arr, ref fill_arr, index + 1_usize, count - 1_usize)
+}

--- a/quaireaux/utils/src/lib.cairo
+++ b/quaireaux/utils/src/lib.cairo
@@ -1,7 +1,5 @@
 mod utils;
 
-use utils::count_digits_of_base;
-use utils::pow;
 use utils::array_slice;
 
 #[cfg(test)]

--- a/quaireaux/utils/src/tests/utils_test.cairo
+++ b/quaireaux/utils/src/tests/utils_test.cairo
@@ -3,31 +3,7 @@ use option::OptionTrait;
 use array::ArrayTrait;
 use traits::Into;
 
-use utils::count_digits_of_base;
-use utils::pow;
 use utils::array_slice;
-
-// Test power function
-#[test]
-#[available_gas(2000000)]
-fn count_digits_of_base_test() {
-    assert(count_digits_of_base(0, 10) == 0, 'invalid result');
-    assert(count_digits_of_base(2, 10) == 1, 'invalid result');
-    assert(count_digits_of_base(10, 10) == 2, 'invalid result');
-    assert(count_digits_of_base(100, 10) == 3, 'invalid result');
-    assert(count_digits_of_base(0x80, 16) == 2, 'invalid result');
-    assert(count_digits_of_base(0x800, 16) == 3, 'invalid result');
-    assert(count_digits_of_base(0x888888888888888888, 16) == 18, 'invalid result');
-}
-
-// Test for power function
-#[test]
-#[available_gas(2000000)]
-fn pow_test() {
-    assert(pow(2, 0) == 1, 'invalid result');
-    assert(pow(2, 1) == 2, 'invalid result');
-    assert(pow(2, 12) == 4096, 'invalid result');
-}
 
 #[test]
 #[available_gas(2000000)]

--- a/quaireaux/utils/src/utils.cairo
+++ b/quaireaux/utils/src/utils.cairo
@@ -4,14 +4,6 @@ use option::OptionTrait;
 use traits::TryInto;
 use traits::Into;
 
-/// Panic with a custom message.
-/// # Arguments
-/// * `msg` - The message to panic with. Must be a short string to fit in a felt252.
-fn panic_with(err: felt252) {
-    let mut data = ArrayTrait::new();
-    data.append(err);
-    panic(data);
-}
 
 /// Convert a `felt252` to a `NonZero` type.
 /// # Arguments
@@ -25,98 +17,6 @@ fn to_non_zero(felt252: felt252) -> Option::<NonZero::<felt252>> {
         IsZeroResult::Zero(()) => Option::<NonZero::<felt252>>::None(()),
         IsZeroResult::NonZero(val) => Option::<NonZero::<felt252>>::Some(val),
     }
-}
-
-
-/// Force conversion from `felt252` to `u128`.
-fn unsafe_felt252_to_u128(a: felt252) -> u128 {
-    a.try_into().unwrap()
-}
-
-/// Perform euclidean division on `felt252` types.
-fn unsafe_euclidean_div_no_remainder(a: felt252, b: felt252) -> felt252 {
-    let a_u128 = unsafe_felt252_to_u128(a);
-    let b_u128 = unsafe_felt252_to_u128(b);
-    (a_u128 / b_u128).into()
-}
-
-fn unsafe_euclidean_div(a: felt252, b: felt252) -> (felt252, felt252) {
-    let a_u128 = unsafe_felt252_to_u128(a);
-    let b_u128 = unsafe_felt252_to_u128(b);
-    ((a_u128 / b_u128).into(), (a_u128 % b_u128).into())
-}
-
-// Function to count the number of digits in a number.
-/// # Arguments
-/// * `num` - The number to count the digits of.
-/// * `base` - Base in which to count the digits.
-/// # Returns
-/// * `felt252` - The number of digits in num of base
-fn count_digits_of_base(num: felt252, base: felt252) -> felt252 {
-    check_gas();
-
-    match num {
-        0 => 0,
-        _ => {
-            let quotient = unsafe_euclidean_div_no_remainder(num, base);
-            count_digits_of_base(quotient, base) + 1
-        }
-    }
-}
-
-// Raise a number to a power.
-/// * `base` - The number to raise.
-/// * `exp` - The exponent.
-/// # Returns
-/// * `felt252` - The result of base raised to the power of exp.
-fn pow(base: felt252, exp: felt252) -> felt252 {
-    check_gas();
-
-    match exp {
-        0 => 1,
-        _ => base * pow(base, exp - 1),
-    }
-}
-
-// Split an array into two arrays.
-/// * `arr` - The array to split.
-/// * `index` - The index to split the array at.
-/// # Returns
-/// * `(Array::<T>, Array::<T>)` - The two arrays.
-fn split_array<T, impl TCopy: Copy::<T>>(
-    ref arr: Array::<T>, index: usize
-) -> (Array::<T>, Array::<T>) {
-    check_gas();
-
-    let mut arr1 = ArrayTrait::new();
-    let mut arr2 = ArrayTrait::new();
-    let len = arr.len();
-
-    fill_array(ref arr1, ref arr, 0_u32, index);
-    fill_array(ref arr2, ref arr, index, len - index);
-
-    (arr1, arr2)
-}
-
-// Fill an array with a value.
-/// * `arr` - The array to fill.
-/// * `fill_arr` - The array to fill with.
-/// * `index` - The index to start filling at.
-/// * `count` - The number of elements to fill.
-/// # Returns
-/// * `Array::<T>` - The filled array.
-fn fill_array<T, impl TCopy: Copy::<T>>(
-    ref arr: Array::<T>, ref fill_arr: Array::<T>, index: usize, count: usize
-) {
-    check_gas();
-
-    if count == 0_usize {
-        return ();
-    }
-    let element = fill_arr.at(index);
-    arr.append(*element);
-
-    fill_array(ref arr, ref fill_arr, index + 1_usize, count - 1_usize)
 }
 
 // Fill an array with a value.


### PR DESCRIPTION
## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Utils crate should ultimately contain only stuff that can be used by all other crates and shouldn't be cluttered with code used by only 1 crate

## What is the new behavior?

Moved all math related stuff from utils to a math file within math.