### PR TITLE
fix: loop keyword reserved

### DIFF
--- a/quaireaux/math/src/extended_euclidean_algorithm.cairo
+++ b/quaireaux/math/src/extended_euclidean_algorithm.cairo
@@ -25,12 +25,12 @@ fn extended_euclidean_algorithm(a: felt252, b: felt252) -> (felt252, felt252, fe
     let mut coeff_t = 1;
 
     // Loop until remainder is 0.
-    loop(ref old_r, ref rem, ref old_s, ref coeff_s, ref old_t, ref coeff_t);
+    loop_euclidian(ref old_r, ref rem, ref old_s, ref coeff_s, ref old_t, ref coeff_t);
     (old_r, old_s, old_t)
 }
 
 
-fn loop(
+fn loop_euclidian(
     ref old_r: felt252,
     ref rem: felt252,
     ref old_s: felt252,
@@ -52,7 +52,7 @@ fn loop(
     update_step(ref coeff_t, ref old_t, quotient);
 
     // Loop again.
-    loop(ref old_r, ref rem, ref old_s, ref coeff_s, ref old_t, ref coeff_t);
+    loop_euclidian(ref old_r, ref rem, ref old_s, ref coeff_s, ref old_t, ref coeff_t);
 }
 
 /// Update the step of the extended Euclidean algorithm.


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Loop is now a reserved keyword with the upcoming Cairo release. I renamed a function called `loop` to `loop_euclidian`
## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
