### PR TITLE
Fix merkle tree alpha6

### DIFF
--- a/quaireaux/data_structures/src/lib.cairo
+++ b/quaireaux/data_structures/src/lib.cairo
@@ -2,7 +2,7 @@ mod data_structures;
 use data_structures::array_slice;
 
 mod array_ext;
-// mod merkle_tree; // Broken atm
+mod merkle_tree;
 mod queue;
 mod stack;
 

--- a/quaireaux/data_structures/src/merkle_tree.cairo
+++ b/quaireaux/data_structures/src/merkle_tree.cairo
@@ -16,6 +16,7 @@
 use array::ArrayTrait;
 use option::OptionTrait;
 use hash::LegacyHash;
+use traits::Into;
 
 /// MerkleTree representation.
 #[derive(Drop)]
@@ -100,11 +101,11 @@ fn internal_compute_root(
     // TODO: enable when bug is fixed
     // thread 'main' panicked at 'Failed to specialize: `drop<Pedersen>`', 
     // crates/cairo-lang-sierra-generator/src/utils.rs:202:9
-    //if current_node < proof_element {
-    //node = LegacyHash::hash(current_node, proof_element);
-    //} else {
-    //node = LegacyHash::hash(proof_element, current_node);
-    //}
+    if current_node.into() < proof_element.into() {
+        node = LegacyHash::hash(current_node, proof_element);
+    } else {
+        node = LegacyHash::hash(proof_element, current_node);
+    }
     // Recursively compute the root.
     internal_compute_root(node, proof_index + 1_u32, proof_len - 1_u32, proof)
 }

--- a/quaireaux/data_structures/src/merkle_tree.cairo
+++ b/quaireaux/data_structures/src/merkle_tree.cairo
@@ -93,7 +93,7 @@ fn internal_compute_root(
     }
     let mut node = 0;
     // Get the next element of the proof.
-    let proof_element = proof.at(proof_index);
+    let proof_element = *proof.at(proof_index);
 
     // Compute the hash of the current node and the current element of the proof.
     // We need to check if the current node is smaller than the current element of the proof.

--- a/quaireaux/data_structures/src/tests.cairo
+++ b/quaireaux/data_structures/src/tests.cairo
@@ -1,6 +1,6 @@
 mod data_structures_test;
 
 mod array_ext_test;
-// mod merkle_tree_test; // Broken atm
+mod merkle_tree_test;
 mod queue_test;
 mod stack_test;


### PR DESCRIPTION
This PR fixes and enables the merkle tree implementation in quaireaux.

This PR is rebased on top of master, supersedes  #76 

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Merkle tree implementation is not working nor ready because the core of it is commented out. This was previously because of a bug in Cairo, but that bug is fixed now.

## What is the new behavior?

Merkle tree is now usable and has working tests.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->