### PR TITLE
Fix Readme typo for storage crate

### DIFF
--- a/src/storage/README.md
+++ b/src/storage/README.md
@@ -6,7 +6,7 @@ An ordered sequence of values that can be used in Starknet storage:
 
 ```rust
 #[storage]
-stuct Storage {
+struct Storage {
     amounts: List<u128>
 }
 ```


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
There is a typo in **storage** crate **README** file. instead of `stuct`, it should be `struct`
## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Typo mistake in README content
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Fixed typo mistake
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
