### PR TITLE
Fix : out-of-bounds access allowed in BytesIndex::index

### DIFF
--- a/packages/bytes/src/bytes.cairo
+++ b/packages/bytes/src/bytes.cairo
@@ -46,6 +46,8 @@ pub struct Bytes {
 pub impl BytesIndex of IndexView<Bytes, usize> {
     type Target = @u128;
     fn index(self: @Bytes, index: usize) -> @u128 {
+        let max_valid_index = (*self.size + BYTES_PER_ELEMENT - 1) / BYTES_PER_ELEMENT;
+        assert(index < max_valid_index, 'Index out of bounds');
         self.data[index]
     }
 }

--- a/packages/bytes/tests/test_bytes_index_bounds.cairo
+++ b/packages/bytes/tests/test_bytes_index_bounds.cairo
@@ -1,0 +1,63 @@
+use alexandria_bytes::bytes::BytesTrait;
+
+#[test]
+fn test_index_within_bounds() {
+    let bytes = BytesTrait::new(16, array![0x11111111111111111111111111111111]);
+
+    let value = bytes[0];
+    assert(*value == 0x11111111111111111111111111111111, 'value mismatch');
+}
+
+#[test]
+fn test_index_multiple_elements() {
+    // size=33 bytes requires ceil(33/16) = 3 elements
+    let bytes = BytesTrait::new(
+        33,
+        array![
+            0x11111111111111111111111111111111, 0x22222222222222222222222222222222,
+            0x33000000000000000000000000000000,
+        ],
+    );
+
+    let first = bytes[0];
+    let second = bytes[1];
+    let third = bytes[2];
+
+    assert(*first == 0x11111111111111111111111111111111, 'first mismatch');
+    assert(*second == 0x22222222222222222222222222222222, 'second mismatch');
+    assert(*third == 0x33000000000000000000000000000000, 'third mismatch');
+}
+
+#[test]
+#[should_panic(expected: ('Index out of bounds',))]
+fn test_index_out_of_bounds() {
+    let bytes = BytesTrait::new(16, array![0x11111111111111111111111111111111]);
+    let _ = bytes[1];
+}
+
+#[test]
+#[should_panic(expected: ('Index out of bounds',))]
+fn test_index_way_out_of_bounds() {
+    let bytes = BytesTrait::new(16, array![0x11111111111111111111111111111111]);
+    let _ = bytes[100];
+}
+
+#[test]
+fn test_index_at_boundary() {
+    // size=32 bytes = exactly 2 elements
+    let bytes = BytesTrait::new(
+        32, array![0x11111111111111111111111111111111, 0x22222222222222222222222222222222],
+    );
+
+    let _ = bytes[0];
+    let _ = bytes[1];
+}
+
+#[test]
+#[should_panic(expected: ('Index out of bounds',))]
+fn test_index_exceeds_boundary() {
+    let bytes = BytesTrait::new(
+        32, array![0x11111111111111111111111111111111, 0x22222222222222222222222222222222],
+    );
+    let _ = bytes[2];
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fix out of bound access in BytesIndex::index


## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
