### PR TITLE
Fix out of bound in ByteArrayTraitExtImpl::read_u8()

### DIFF
--- a/packages/bytes/src/byte_array_ext.cairo
+++ b/packages/bytes/src/byte_array_ext.cairo
@@ -352,10 +352,10 @@ pub impl ByteArrayTraitExtImpl of ByteArrayTraitExt {
         self.len()
     }
 
-    /// Read a u_ from ByteArray
+    /// Read a u8 from ByteArray
     #[inline(always)]
     fn read_u8(self: @ByteArray, offset: usize) -> (usize, u8) {
-        assert(offset <= self.len(), 'out of bound');
+        assert(offset < self.len(), 'out of bound');
         (offset + 1, self.at(offset).unwrap())
     }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-Fix out of bound in ByteArrayTraitExtImpl::read_u8()

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
