### PR TITLE
Fix ByteArrayTraitExt read_uint() size adjustment

### DIFF
--- a/packages/bytes/src/byte_array_ext.cairo
+++ b/packages/bytes/src/byte_array_ext.cairo
@@ -861,15 +861,9 @@ pub impl ByteArrayAppenderImpl of ByteAppender<T: ByteArray> {
 ///   - The new offset after reading the specified number of bytes.
 ///   - The value of type T read from the ByteArray.
 fn read_uint<T, +Add<T>, +Mul<T>, +Zero<T>, +TryInto<felt252, T>, +Drop<T>, +Into<u8, T>>(
-    self: @ByteArray, offset: usize, mut size: usize,
+    self: @ByteArray, offset: usize, size: usize,
 ) -> (usize, T) {
-    // Uncomment the following line to enforce bounds checking
     assert(offset + size <= self.len(), 'out of bound');
-
-    // Adjust size if it exceeds the length of the ByteArray
-    if size > self.len() && offset == 0 {
-        size = self.len() - offset;
-    }
 
     let mut value: T = Zero::zero();
     let mut i = 0;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-Fix ByteArrayTraitExt read_uint() size adjustment

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
