### PR TITLE
fix(evm): modify the offset on `decode_bytes_32`

### DIFF
--- a/packages/evm/src/decoder.cairo
+++ b/packages/evm/src/decoder.cairo
@@ -287,7 +287,9 @@ fn decode_bytes(ref ctx: EVMCalldata) -> Span<felt252> {
 /// A `Span<felt252>` containing 32 bytes split into 31 bytes and the MSB.
 #[inline(always)]
 fn decode_bytes_32(ref ctx: EVMCalldata) -> Span<felt252> {
-    let (_, value) = ctx.calldata.read_u256(ctx.offset);
+    let (new_offset, value) = ctx.calldata.read_u256(ctx.offset);
+
+    ctx.offset = new_offset;
 
     let mut ba: ByteArray = Default::default();
     ba.append_u256(value);

--- a/packages/evm/tests/decoder_tests.cairo
+++ b/packages/evm/tests/decoder_tests.cairo
@@ -907,3 +907,38 @@ fn test_decode_transfer_from() {
     assert!(*decoded.at(2) == expected_to.into());
     assert!(*decoded.at(3) == expected_amount.into());
 }
+
+#[test]
+fn test_decode_multiple_bytes32() {
+    let mut data: ByteArray = Default::default();
+
+    data.append_u256(0x1111111111111111111111111111111111111111111111111111111111111111);
+    data.append_u256(0x2222222222222222222222222222222222222222222222222222222222222222);
+    data.append_u256(0x3333333333333333333333333333333333333333333333333333333333333333);
+    data.append_u256(0x4444444444444444444444444444444444444444444444444444444444444444);
+
+    let mut calldata = cd(data);
+
+    let decoded = calldata
+        .decode(
+            array![EVMTypes::Bytes32, EVMTypes::Bytes32, EVMTypes::Bytes32, EVMTypes::Bytes32]
+                .span(),
+        );
+
+    assert!(*decoded.at(0) == 1);
+    assert!(*decoded.at(1) == 0x11111111111111111111111111111111111111111111111111111111111111);
+    assert!(*decoded.at(2) == 0x11);
+    assert!(*decoded.at(3) == 1);
+    assert!(*decoded.at(4) == 1);
+    assert!(*decoded.at(5) == 0x22222222222222222222222222222222222222222222222222222222222222);
+    assert!(*decoded.at(6) == 0x22);
+    assert!(*decoded.at(7) == 1);
+    assert!(*decoded.at(8) == 1);
+    assert!(*decoded.at(9) == 0x33333333333333333333333333333333333333333333333333333333333333);
+    assert!(*decoded.at(10) == 0x33);
+    assert!(*decoded.at(11) == 1);
+    assert!(*decoded.at(12) == 1);
+    assert!(*decoded.at(13) == 0x44444444444444444444444444444444444444444444444444444444444444);
+    assert!(*decoded.at(14) == 0x44);
+    assert!(*decoded.at(15) == 1);
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

I wasn't able to ethabi-decode a type that contains `bytes32`. Then I realized that it's because the offset is not modified after the data is read.   

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Modify the offset so that after parsing `bytes32`, the offset is increased accordingly.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
